### PR TITLE
Update patches

### DIFF
--- a/svd/device/periph/rtc.yaml
+++ b/svd/device/periph/rtc.yaml
@@ -1,0 +1,5 @@
+"RTC*":
+  _delete:
+    - "BCNT*"
+    - "RCR2_BCNT"
+    

--- a/svd/device/periph/usb.yaml
+++ b/svd/device/periph/usb.yaml
@@ -1,0 +1,9 @@
+USBHS:
+  "DEVADD%s":
+    _modify:
+      UPPHUB:
+        _write_constraint: [0, 10]
+  DEVADDA:
+    _modify:
+      UPPHUB:
+        _write_constraint: [0, 10]

--- a/svd/device/r7fa2e1a9.yaml
+++ b/svd/device/r7fa2e1a9.yaml
@@ -1,1 +1,4 @@
 _svd: "../patch/r7fa2e1a9.svd"
+
+_include: 
+  - "periph/rtc.yaml"

--- a/svd/device/r7fa2l1ab.yaml
+++ b/svd/device/r7fa2l1ab.yaml
@@ -1,1 +1,4 @@
 _svd: "../patch/r7fa2l1ab.svd"
+
+_include: 
+  - "periph/rtc.yaml"

--- a/svd/device/r7fa4e10d.yaml
+++ b/svd/device/r7fa4e10d.yaml
@@ -1,1 +1,4 @@
 _svd: "../patch/r7fa4e10d.svd"
+
+_include: 
+  - "periph/rtc.yaml"

--- a/svd/device/r7fa4m2ad.yaml
+++ b/svd/device/r7fa4m2ad.yaml
@@ -2,3 +2,4 @@ _svd: "../patch/r7fa4m2ad.svd"
 
 _include: 
   - "periph/sdhi.yaml"
+  - "periph/rtc.yaml"

--- a/svd/device/r7fa4m3af.yaml
+++ b/svd/device/r7fa4m3af.yaml
@@ -2,3 +2,4 @@ _svd: "../patch/r7fa4m3af.svd"
 
 _include: 
   - "periph/sdhi.yaml"
+  - "periph/rtc.yaml"

--- a/svd/device/r7fa6e10f.yaml
+++ b/svd/device/r7fa6e10f.yaml
@@ -2,3 +2,4 @@ _svd: "../patch/r7fa6e10f.svd"
 
 _include: 
   - "periph/sdhi.yaml"
+  - "periph/rtc.yaml"

--- a/svd/device/r7fa6m2af.yaml
+++ b/svd/device/r7fa6m2af.yaml
@@ -1,1 +1,4 @@
 _svd: "../patch/r7fa6m2af.svd"
+
+_include: 
+  - "periph/usb.yaml"

--- a/svd/device/r7fa6m3ah.yaml
+++ b/svd/device/r7fa6m3ah.yaml
@@ -1,1 +1,4 @@
 _svd: "../patch/r7fa6m3ah.svd"
+
+_include: 
+  - "periph/usb.yaml"

--- a/svd/device/r7fa6m4af.yaml
+++ b/svd/device/r7fa6m4af.yaml
@@ -2,3 +2,4 @@ _svd: "../patch/r7fa6m4af.svd"
 
 _include: 
   - "periph/sdhi.yaml"
+  - "periph/rtc.yaml"

--- a/svd/device/r7fa6m5bh.yaml
+++ b/svd/device/r7fa6m5bh.yaml
@@ -2,6 +2,7 @@ _svd: "../patch/r7fa6m5bh.svd"
 
 _include: 
   - "periph/sdhi.yaml"
+  - "periph/rtc.yaml"
 
 USBHS:
   DCPCTR:

--- a/update-pacs.py
+++ b/update-pacs.py
@@ -7,11 +7,20 @@ import re
 # Define dependencies
 deps = '''
 [dependencies]
-critical-section = { version = "1.1", optional = true }
 cortex-m = "0.7"
-cortex-m-rt = { version = "0.6", optional = true }
-vcell = "0.1"
-portable-atomic = { version = "0.3", default-features = false, optional = true }
+vcell = "0.1.2"
+
+[dependencies.portable-atomic]
+optional = true
+version = "0.3"
+
+[dependencies.cortex-m-rt]
+optional = true
+version = "0.7.3"
+
+[dependencies.critical-section]
+optional = true
+version = "1.1.2"
 
 [features]
 rt = ["cortex-m-rt/device"]


### PR DESCRIPTION
With these changes, `svd2rust` can generate all the PACs, however pretty much every one of them fails to build because the generated code has wrongly named structures (hence, a draft PR for now).